### PR TITLE
Fix syntax error in metadata.json.

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,7 @@
 fixtures:
   repositories:
     apt: "git://github.com/puppetlabs/puppetlabs-apt.git"
+    epel: "git://github.com/stahnma/puppet-module-epel.git"
     stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
   symlinks:
     sysdig: "#{source_dir}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
   - PUPPET_VERSION="~> 3.4.0"
   - PUPPET_VERSION="~> 3.5.0"
   - PUPPET_VERSION="~> 3.6.0"
+  - PUPPET_VERSION="~> 3.7.0"
 matrix:
   exclude:
   - rvm: 1.9.3

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,2 +1,6 @@
 2014-08-10 Release 0.1.0
 - Initial working release
+2014-09-14 Release 0.1.1
+- Fix metadata.json syntax
+2014-09-14 Release 0.1.2
+- Fix RHEL and CentOS support

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name          'garethr-sysdig'
-version       '0.1.1'
+version       '0.1.2'
 source        'git://github.com/garethr/garethr-sysdig.git'
 author        'Gareth Rushgrove'
 license       'Apache 2.0'
@@ -9,3 +9,4 @@ project_page  'https://github.com/garethr/garethr-sysdig'
 
 dependency 'puppetlabs/stdlib'
 dependency 'puppetlabs/apt'
+dependency 'stahnma/epel'

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name          'garethr-sysdig'
-version       '0.1.0'
+version       '0.1.1'
 source        'git://github.com/garethr/garethr-sysdig.git'
 author        'Gareth Rushgrove'
 license       'Apache 2.0'

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -24,7 +24,7 @@ class sysdig::install {
       ]
     }
     'RedHat': {
-
+      include 'epel'
       yumrepo { 'sysdig':
         baseurl  => 'http://download.draios.com/stable/rpm/$basearch',
         descr    => 'Sysdig repository by Draios',
@@ -32,7 +32,9 @@ class sysdig::install {
         gpgcheck => 0,
       }
 
-      $dependencies = Yumrepo['sysdig']
+      ensure_packages(["kernel-devel-${::kernelrelease}"])
+
+      $dependencies = [ Yumrepo['sysdig'], Class['epel'] ]
     }
     default: {
       $dependencies = []

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "garethr-sysdig",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "source": "git://github.com/garethr/garethr-sysdig.git",
   "author": "Gareth Rushgrove",
   "license": "Apache 2.0",
@@ -8,7 +8,7 @@
   "description": "Install sysdig from the official repositories",
   "project_page": "https://github.com/garethr/garethr-sysdig",
   "dependencies": [
-    {"name": "puppetlabs-apt"},
-    {"name": "puppetlabs-stdlib"}
+    {"name": "puppetlabs/apt"},
+    {"name": "puppetlabs/stdlib"}
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "garethr-sysdig",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "source": "git://github.com/garethr/garethr-sysdig.git",
   "author": "Gareth Rushgrove",
   "license": "Apache 2.0",
@@ -9,6 +9,7 @@
   "project_page": "https://github.com/garethr/garethr-sysdig",
   "dependencies": [
     {"name": "puppetlabs/apt"},
-    {"name": "puppetlabs/stdlib"}
+    {"name": "puppetlabs/stdlib"},
+    {"name": "stahnma/epel"}
   ]
 }

--- a/spec/classes/example_spec.rb
+++ b/spec/classes/example_spec.rb
@@ -16,11 +16,13 @@ describe 'sysdig' do
 
     if osfamily == 'RedHat'
       let(:facts) {{
-        :osfamily => osfamily,
+        :osfamily      => osfamily,
+        :kernelrelease => '3.10.0-123.el7.x86_64',
       }}
 
       context 'on Redhat' do
         describe 'should install required repo' do
+          it { should contain_yumrepo('epel') }
           it { should contain_yumrepo('sysdig') }
         end
       end
@@ -32,6 +34,7 @@ describe 'sysdig' do
       it { should contain_class('sysdig::params') }
       it { should contain_class('sysdig::install') }
 
+      it { should contain_package('kernel-devel-3.10.0-123.el7.x86_64') }
       it { should contain_package('sysdig').with_ensure('installed') }
     end
 


### PR DESCRIPTION
The author and module names in the dependencies
section of the metadata.json files shold be
separted with a "/" not a "-".

I have run the below tests are they come back successful.

```
bundle exec rake lint
bundle exec rake syntax
bundle exec rake spec
```

I have also verified that the module builds cleanly by doing a "puppet module build".
