### PR TITLE
Fix some warnings from the apt module

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -7,12 +7,7 @@ class sysdig::install {
 
       include apt
 
-      package { 'debian-keyring':
-        ensure => 'installed',
-      }
-      package { 'debian-archive-keyring':
-        ensure => 'installed',
-      }
+      ensure_packages(['debian-keyring', 'debian-archive-keyring'])
 
       apt::source { 'sysdig':
         location => 'http://download.draios.com/stable/deb',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -24,6 +24,7 @@ class sysdig::install {
           'debian-keyring',
           'debian-archive-keyring'
         ],
+        before => Package['sysdig'],
       }
 
       ensure_packages(["linux-headers-${::kernelrelease}"])

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -18,13 +18,13 @@ class sysdig::install {
           source => 'https://s3.amazonaws.com/download.draios.com/DRAIOS-GPG-KEY.public',
         },
         include  => {
-          src    => false,
+          src => false,
         },
         require  => Package[
           'debian-keyring',
           'debian-archive-keyring'
         ],
-        before => Package['sysdig'],
+        before   => Package['sysdig'],
       }
 
       ensure_packages(["linux-headers-${::kernelrelease}"])

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -6,14 +6,29 @@ class sysdig::install {
     'Debian': {
 
       include apt
+
+      package { 'debian-keyring':
+        ensure => 'installed',
+      }
+      package { 'debian-archive-keyring':
+        ensure => 'installed',
+      }
+
       apt::source { 'sysdig':
-        location          => 'http://download.draios.com/stable/deb',
-        release           => 'stable-$(ARCH)/',
-        repos             => '',
-        required_packages => 'debian-keyring debian-archive-keyring',
-        key               => 'EC51E8C4',
-        key_source        => 'https://s3.amazonaws.com/download.draios.com/DRAIOS-GPG-KEY.public',
-        include_src       => false,
+        location => 'http://download.draios.com/stable/deb',
+        release  => 'stable-$(ARCH)/',
+        repos    => '',
+        key      => {
+          id     => 'D27A72F32D867DF9300A241574490FD6EC51E8C4',
+          source => 'https://s3.amazonaws.com/download.draios.com/DRAIOS-GPG-KEY.public',
+        },
+        include  => {
+          src    => false,
+        },
+        require  => Package[
+          'debian-keyring',
+          'debian-archive-keyring'
+        ],
       }
 
       ensure_packages(["linux-headers-${::kernelrelease}"])


### PR DESCRIPTION
There are some warnings about usage of deprecated api in the apt module when using this module on debian. Use the current api of the apt module to avoid warnings now and potential breakage later
